### PR TITLE
feat: add column lookup feature for value transformation

### DIFF
--- a/src/data_sync/database.py
+++ b/src/data_sync/database.py
@@ -1016,7 +1016,9 @@ class DatabaseConnection:
                 row_data = {}
                 for col_mapping in sync_columns:
                     if col_mapping.csv_column in row:
-                        row_data[col_mapping.db_column] = row[col_mapping.csv_column]
+                        csv_value = row[col_mapping.csv_column]
+                        # Apply lookup transformation if configured
+                        row_data[col_mapping.db_column] = col_mapping.apply_lookup(csv_value)
 
                 # Add filename values if configured
                 if job.filename_to_column and filename_values:
@@ -1036,7 +1038,9 @@ class DatabaseConnection:
                 row_data = {}
                 for col_mapping in sync_columns:
                     if col_mapping.csv_column in row:
-                        row_data[col_mapping.db_column] = row[col_mapping.csv_column]
+                        csv_value = row[col_mapping.csv_column]
+                        # Apply lookup transformation if configured
+                        row_data[col_mapping.db_column] = col_mapping.apply_lookup(csv_value)
 
                 # Add filename values if configured
                 if job.filename_to_column and filename_values:
@@ -1094,7 +1098,9 @@ class DatabaseConnection:
                     row_data = {}
                     for col_mapping in sync_columns:
                         if col_mapping.csv_column in row:
-                            row_data[col_mapping.db_column] = row[col_mapping.csv_column]
+                            csv_value = row[col_mapping.csv_column]
+                            # Apply lookup transformation if configured
+                            row_data[col_mapping.db_column] = col_mapping.apply_lookup(csv_value)
 
                     # Add filename values if configured
                     if job.filename_to_column and filename_values:
@@ -1112,7 +1118,9 @@ class DatabaseConnection:
                     row_data = {}
                     for col_mapping in sync_columns:
                         if col_mapping.csv_column in row:
-                            row_data[col_mapping.db_column] = row[col_mapping.csv_column]
+                            csv_value = row[col_mapping.csv_column]
+                            # Apply lookup transformation if configured
+                            row_data[col_mapping.db_column] = col_mapping.apply_lookup(csv_value)
 
                     # Add filename values if configured
                     if job.filename_to_column and filename_values:


### PR DESCRIPTION
Add support for transforming CSV values to different database values using lookup dictionaries. This is useful for standardizing data, converting human-readable strings to codes, and mapping between different systems.

Features:
- Lookup dictionaries map CSV values to database values
- Values not in lookup pass through unchanged (no error)
- Works with all data types (string-to-int, string-to-string, etc.)
- Can be combined with type specification for conversions
- Supports multiple lookup columns in a single job
- Works with both regular columns and id_mapping

Implementation:
- Added lookup parameter to ColumnMapping class
- Added apply_lookup() method to handle transformations
- Updated config parsing to read lookup dictionaries from YAML
- Updated config serialization to write lookups back to YAML
- Modified _process_csv_rows() to apply lookups during sync
- Modified _count_and_track_csv_rows() for dry-run support

Tests:
- Added 8 config tests for parsing, validation, and serialization
- Added 4 integration tests for various lookup scenarios:
  * String to integer transformation
  * String to string transformation
  * Passthrough of unknown values
  * Multiple lookup columns
- All existing tests continue to pass (189 tests)

Documentation:
- Added comprehensive "Column Lookups" section to configuration.md
- Documented lookup behavior and examples
- Added best practice for using lookups
- Included examples for various use cases

Example Usage:
```yaml
columns:
  status:
    db_column: status_code
    type: integer
    lookup:
      active: 1
      inactive: 0
      pending: 2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)