### PR TITLE
Upload Linux 3.14 test report to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     name: Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       checks: write
     strategy:
@@ -98,7 +98,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -107,6 +107,7 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ github.token }}
+          COVERAGE_DATA_BRANCH: ${{ github.head_ref || github.ref_name }}
           MINIMUM_GREEN: 80
           MINIMUM_ORANGE: 70
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ filterwarnings = [
 [tool.coverage.run]
 source = ["src/crump"]
 omit = ["*/tests/*", "*/__pycache__/*"]
+relative_files = true
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
- Generate JUnit XML test results for Linux 3.14 build
- Upload test results as artifacts for each test run
- Add test report visualization using EnricoMi/publish-unit-test-result-action
- Enable PR code coverage comments using py-cov-action/python-coverage-comment-action
- Add necessary permissions for PR comments and check creation
- Configure pytest to generate coverage XML and JUnit reports